### PR TITLE
Replace a script for Heroku.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "dev": "vue-cli-service serve",
     "lint": "vue-cli-service lint",
-    "postinstall": "yarn build"
+    "heroku-postbuild": "yarn build"
   },
   "dependencies": {
     "express": "^4.16.4",


### PR DESCRIPTION
`postinstall` trigger to build after 'yarn' so simply replace it with a script `heroku-postbuild` is run only by heroku.